### PR TITLE
Restart acadock-monitoring systemd service when docker is restarted

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,6 +47,8 @@ if node['init_package'] == 'systemd'
       'Unit' => {
         'Description' => 'Acadock - Docker monitoring tool',
         'After' => 'network.target docker.service',
+        'Requires' => 'docker.service',
+        'PartOf' => 'docker.service',
       },
       'Service' => {
         'ExecStart' => File.join(acadock_dir, 'acadock-monitoring'),
@@ -55,7 +57,7 @@ if node['init_package'] == 'systemd'
         'Environment' => env,
       },
       'Install' => {
-        'WantedBy' => 'multi-user.target',
+        'WantedBy' => 'docker.service',
       }
     }
     content systemd_content


### PR DESCRIPTION
It happened multiple times that after a maintenance requiring a server to restart docker daemon. Metrics collection was broken as acadock was not detecting new containers