### PR TITLE
release: Use v1.2.0 by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ acadock CHANGELOG
 
 This file is used to list changes made in each version of the acadock cookbook.
 
+1.2.0
+-----
+* [brandon-welsch] Default acadock version is 1.2.0
+
 1.1.0
 -----
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default['acadock'] = {
   'download_url' => 'https://github.com/Scalingo/acadock-monitoring/releases/download',
-  'version' => '1.1.0',
+  'version' => '1.2.0',
   'arch' => 'amd64',
   'install_path' => '/opt',
   'docker_url' => 'http://127.0.0.1:4243',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'leo@scalingo.com'
 license          'MIT'
 description      'Installs/Configures acadock monitoring tool'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.0'
+version          '1.2.0'


### PR DESCRIPTION
Related to https://github.com/Scalingo/acadock-monitoring/releases/tag/v1.2.0

@Soulou Can you make a release on Chef Supermarket: https://supermarket.chef.io/cookbooks/acadock