### PR TITLE
release: use v1.2.1 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-acadock CHANGELOG
-=================
+# acadock CHANGELOG
 
 This file is used to list changes made in each version of the acadock cookbook.
 
+## 1.2.1
+
+* Default acadock version is 1.2.1
+
 1.2.0
 -----
+
 * [brandon-welsch] Default acadock version is 1.2.0
 
 1.1.0
@@ -123,8 +127,3 @@ This file is used to list changes made in each version of the acadock cookbook.
 0.1.0
 -----
 * [Soulou] - Initial release of acadock
-
-- - -
-Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.
-
-The [Github Flavored Markdown page](http://github.github.com/github-flavored-markdown/) describes the differences between markdown on github and standard markdown.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default['acadock'] = {
   'download_url' => 'https://github.com/Scalingo/acadock-monitoring/releases/download',
-  'version' => '1.2.0',
+  'version' => '1.2.1',
   'arch' => 'amd64',
   'install_path' => '/opt',
   'docker_url' => 'http://127.0.0.1:4243',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'leo@scalingo.com'
 license          'MIT'
 description      'Installs/Configures acadock monitoring tool'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.0'
+version          '1.2.1'


### PR DESCRIPTION
Related to https://github.com/Scalingo/acadock-monitoring/releases/tag/v1.2.1